### PR TITLE
Disable hostgroup module

### DIFF
--- a/manifests/foreman.pp
+++ b/manifests/foreman.pp
@@ -21,7 +21,6 @@ class profile::foreman (
   include foreman_proxy
   include puppet
   include foreman::cli
-  include foreman::plugin::default_hostgroup
   include foreman::plugin::setup
   include foreman::compute::ec2
 


### PR DESCRIPTION
The foreman upgrade broke puppet because of this plugin.