### PR TITLE
DEVSUPPORT228 Fixed resource collector name

### DIFF
--- a/manifests/squid_client.pp
+++ b/manifests/squid_client.pp
@@ -18,12 +18,13 @@ class profile::squid_client (
     ## Firewall
     if str2bool($::settings::storeconfigs) {
         # Pick up the rules that were left for us.
-        Firewall <<| tag == 'fw_squid_out' |>>
+        Firewall <<| tag == 'fw_proxy_out' |>>
     }
 
+    #Is this redundant with the exported resource in squid.pp?
     if ($server_ip) {
       firewall { "200 OUTPUT HTTP Proxy to Squid Server ${server_ip} 3128/tcp":
-        dport       => ['80', '443'],
+        dport       => [3128],
         proto       => 'tcp',
         action      => 'accept',
         chain       => 'OUTPUT',


### PR DESCRIPTION
Stuff using the squid_client role won't have correct proxy rules due to a mismatch in the collector name; also adjusted the static rule to use the correct port .